### PR TITLE
Added a `change_dir` option which `cd`s into the select project

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,19 @@ require'telescope'.load_extension('project')
 
 ## Available functions:
 
+### Project
+
+The projects picker.
+
 ```lua
 require'telescope'.extensions.project.project{}
+```
+
+You can optionally pass in `change_dir = true` in order to change the current
+working directory when a project is selected.
+
+```lua
+require'telescope'.extensions.project.project{ change_dir = true }
 ```
 
 ## Example config: 

--- a/lua/telescope/_extensions/project.lua
+++ b/lua/telescope/_extensions/project.lua
@@ -49,7 +49,7 @@ local select_project = function(opts, projects)
       map('n', 'f', project_actions.find_project_files)
       map('n', 's', project_actions.search_in_project_files)
       local on_project_selected = function()
-        project_actions.find_project_files(prompt_bufnr)
+        project_actions.find_project_files(prompt_bufnr, opts.change_dir)
       end
       actions.goto_file_selection_edit:replace(on_project_selected)
       return true

--- a/lua/telescope/_extensions/project_actions.lua
+++ b/lua/telescope/_extensions/project_actions.lua
@@ -66,7 +66,7 @@ end
 project_actions.find_project_files = function(prompt_bufnr, change_dir)
   local dir = actions.get_selected_entry(prompt_bufnr).value
   if change_dir then
-    vim.cmd("cd "..dir)
+    vim.fn.execute("cd " .. dir, "silent")
   end
   builtin.find_files({cwd = dir})
 end

--- a/lua/telescope/_extensions/project_actions.lua
+++ b/lua/telescope/_extensions/project_actions.lua
@@ -63,8 +63,12 @@ project_actions.delete_project = function(prompt_bufnr)
   require 'telescope'.extensions.project.project()
 end
 
-project_actions.find_project_files = function(prompt_bufnr)
-  builtin.find_files({cwd = actions.get_selected_entry(prompt_bufnr).value})
+project_actions.find_project_files = function(prompt_bufnr, change_dir)
+  local dir = actions.get_selected_entry(prompt_bufnr).value
+  if change_dir then
+    vim.cmd("cd "..dir)
+  end
+  builtin.find_files({cwd = dir})
 end
 
 project_actions.search_in_project_files = function(prompt_bufnr)


### PR DESCRIPTION
You can now pass in `{ change_dir = true }` to the `.projects` function. When true, this will change directories when a project is selected. This is useful because it updates any file manages such as `NvimTree` to be in that directory.

Example:

```lua
require'telescope'.extensions.project.project{ change_dir = true }
```