### PR TITLE
Fixed bug that was causing issue #17

### DIFF
--- a/lua/telescope/_extensions/project_actions.lua
+++ b/lua/telescope/_extensions/project_actions.lua
@@ -7,78 +7,82 @@ local project_actions = {}
 local project_dirs_file = vim.fn.stdpath('data') .. '/telescope-projects.txt'
 
 project_actions.add_project = function(prompt_bufnr)
-  local git_root = vim.fn.systemlist("git -C " .. vim.loop.cwd() .. " rev-parse --show-toplevel")[
-    1
-  ]
-  local project_directory = git_root
-  if not git_root then
-    project_directory = vim.loop.cwd()
-    return
-  end
+    local git_root = vim.fn.systemlist("git -C " .. vim.loop.cwd() ..
+                                           " rev-parse --show-toplevel")[1]
 
-  local project_title = project_directory:match("[^/]+$")
-  local project_to_add = project_title .. "=" .. project_directory .. "\n"
-
-  local file = assert(
-    io.open(project_dirs_file, "a"),
-    "No project file exists"
-  )
-
-  local project_already_added = false
-  for line in io.lines(project_dirs_file) do
-    local project_exists_check = line .. "\n" == project_to_add
-    if project_exists_check then
-      project_already_added = true
-      print('This project already exists.')
-      return
+    local project_directory = git_root
+    if not git_root or git_root ==
+        "fatal: not a git repository (or any of the parent directories): .git" then
+        project_directory = vim.loop.cwd()
     end
-  end
+    -- local project_directory = git_root
+    -- if not git_root then
+    -- project_directory = vim.loop.cwd()
+    -- return
+    -- end
 
-  if not project_already_added then
-    io.output(file)
-    io.write(project_to_add)
-    print('project added: ' .. project_title)
-  end
-  io.close(file)
-  actions.close(prompt_bufnr)
-  require 'telescope'.extensions.project.project()
+    local project_title = project_directory:match("[^/]+$")
+    local project_to_add = project_title .. "=" .. project_directory .. "\n"
+
+    local file = assert(io.open(project_dirs_file, "a"),
+                        "No project file exists")
+
+    local project_already_added = false
+    for line in io.lines(project_dirs_file) do
+        local project_exists_check = line .. "\n" == project_to_add
+        if project_exists_check then
+            project_already_added = true
+            print('This project already exists.')
+            return
+        end
+    end
+
+    if not project_already_added then
+        io.output(file)
+        io.write(project_to_add)
+        print('project added: ' .. project_title)
+    end
+    io.close(file)
+    actions.close(prompt_bufnr)
+    require'telescope'.extensions.project.project()
 end
 
 project_actions.delete_project = function(prompt_bufnr)
-  local newLines = ""
-  for line in io.lines(project_dirs_file) do
-    local title, path = line:match("^(.-)=(.-)$")
-    if title ~= actions.get_selected_entry(prompt_bufnr).display then
-      newLines = newLines .. title .. '=' .. path .. "\n"
+    local newLines = ""
+    for line in io.lines(project_dirs_file) do
+        local title, path = line:match("^(.-)=(.-)$")
+        if title ~= actions.get_selected_entry(prompt_bufnr).display then
+            newLines = newLines .. title .. '=' .. path .. "\n"
+        end
     end
-  end
-  local file = assert(
-    io.open(project_dirs_file, "w"),
-    "No project file exists"
-  )
-  file:write(newLines)
-  file:close()
-  print('Project deleted: ' .. actions.get_selected_entry(prompt_bufnr).display)
-  actions.close(prompt_bufnr)
-  require 'telescope'.extensions.project.project()
+    local file = assert(io.open(project_dirs_file, "w"),
+                        "No project file exists")
+    file:write(newLines)
+    file:close()
+    print('Project deleted: ' ..
+              actions.get_selected_entry(prompt_bufnr).display)
+    actions.close(prompt_bufnr)
+    require'telescope'.extensions.project.project()
 end
 
 project_actions.find_project_files = function(prompt_bufnr)
-  local dir = actions.get_selected_entry(prompt_bufnr).value
-  builtin.find_files({cwd = dir})
-  vim.fn.execute("cd " .. dir, "silent")
+    local dir = actions.get_selected_entry(prompt_bufnr).value
+    builtin.find_files({cwd = dir})
+    vim.fn.execute("cd " .. dir, "silent")
 end
 
-project_actions.search_in_project_files = function(prompt_bufnr)
-  local dir = actions.get_selected_entry(prompt_bufnr).value
-  builtin.live_grep({cwd = dir})
-end
+project_actions.search_in_project_files =
+    function(prompt_bufnr)
+        local dir = actions.get_selected_entry(prompt_bufnr).value
+        builtin.live_grep({cwd = dir})
+    end
 
-project_actions.change_working_directory = function(prompt_bufnr)
-  local dir = actions.get_selected_entry(prompt_bufnr).value
-  actions.close(prompt_bufnr)
-  vim.fn.execute("cd " .. dir, "silent")
-end
+project_actions.change_working_directory =
+    function(prompt_bufnr)
+        local dir = actions.get_selected_entry(prompt_bufnr).value
+        actions.close(prompt_bufnr)
+        vim.fn.execute("cd " .. dir, "silent")
+    end
 
 project_actions = transform_mod(project_actions);
 return project_actions


### PR DESCRIPTION
In project_actions.add_project, when git_root is initialized,        #######itsometimes takes value of `fatal: not a git repository (or any of the parent directories): .git`
I added a quick fix to check if the string value  is null or of the
above value to handle this case