### PR TITLE
Add rename function

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ vim.api.nvim_set_keymap(
 
 ## Default mappings (normal mode):
 d: delete currently selected project\
+r: rename currently selected project\
 c: create a project (defaults to your git root if used inside a git project, otherwise will use your current working directory)\
 s: search inside files within your project\
 w: change to the selected project's directory without opening it\

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ w: change to the selected project's directory without opening it\
 f: find a file within your project (this works the same as \<CR\>)
 
 ## Roadmap :blue_car:
-- rename projects :construction:
 - order projects by last opened :construction:
 - workspaces :construction:
 - add all (git-enabled) subdirectories, instead of manually needing to add all projects :construction:

--- a/lua/telescope/_extensions/project.lua
+++ b/lua/telescope/_extensions/project.lua
@@ -43,6 +43,7 @@ local select_project = function(opts, projects)
     sorter = conf.file_sorter(opts),
     attach_mappings = function(prompt_bufnr, map)
       map('n', 'd', project_actions.delete_project)
+      map('n', 'r', project_actions.rename_project)
       map('n', 'c', project_actions.add_project)
       map('n', 'f', project_actions.find_project_files)
       map('n', 's', project_actions.search_in_project_files)

--- a/lua/telescope/_extensions/project_actions.lua
+++ b/lua/telescope/_extensions/project_actions.lua
@@ -48,6 +48,29 @@ project_actions.add_project = function(prompt_bufnr)
   require 'telescope'.extensions.project.project()
 end
 
+project_actions.rename_project = function(prompt_bufnr)
+	local oldName = actions.get_selected_entry(prompt_bufnr).display
+  local newName = vim.fn.input('Rename ' ..oldName.. ' to: ', oldName)
+	local newLines = ""
+  for line in io.lines(project_dirs_file) do
+    local title, path = line:match("^(.-)=(.-)$")
+    if title ~= oldName then
+      newLines = newLines .. title .. '=' .. path .. '\n'
+		else
+			newLines = newLines .. newName .. '=' .. actions.get_selected_entry(prompt_bufnr).value .. '\n'
+    end
+  end
+  local file = assert(
+    io.open(project_dirs_file, "w"),
+    "No project file exists"
+  )
+  file:write(newLines)
+  file:close()
+  print('Project renamed: ' .. actions.get_selected_entry(prompt_bufnr).display .. ' -> ' .. newName)
+  actions.close(prompt_bufnr)
+  require 'telescope'.extensions.project.project()
+end
+
 project_actions.delete_project = function(prompt_bufnr)
   local newLines = ""
   for line in io.lines(project_dirs_file) do

--- a/lua/telescope/_extensions/project_actions.lua
+++ b/lua/telescope/_extensions/project_actions.lua
@@ -49,15 +49,15 @@ project_actions.add_project = function(prompt_bufnr)
 end
 
 project_actions.rename_project = function(prompt_bufnr)
-	local oldName = actions.get_selected_entry(prompt_bufnr).display
+  local oldName = actions.get_selected_entry(prompt_bufnr).display
   local newName = vim.fn.input('Rename ' ..oldName.. ' to: ', oldName)
-	local newLines = ""
+  local newLines = ""
   for line in io.lines(project_dirs_file) do
     local title, path = line:match("^(.-)=(.-)$")
     if title ~= oldName then
       newLines = newLines .. title .. '=' .. path .. '\n'
-		else
-			newLines = newLines .. newName .. '=' .. actions.get_selected_entry(prompt_bufnr).value .. '\n'
+    else
+      newLines = newLines .. newName .. '=' .. actions.get_selected_entry(prompt_bufnr).value .. '\n'
     end
   end
   local file = assert(


### PR DESCRIPTION
Adds a function (and associated keymap) to rename projects.

---

The rename function is basically a modified version of the delete function that prompts the user for a new name.

Currently, the prompt value defaults to the current name, but depending on preference, it may be better to default to nothing.
I'm happy to change this if other people think one way or the other is better.