### PR TITLE
Feat/refactor picker refresh

### DIFF
--- a/lua/telescope/_extensions/project.lua
+++ b/lua/telescope/_extensions/project.lua
@@ -16,6 +16,9 @@ local project_actions = require("telescope._extensions.project_actions")
 
 local project_dirs_file = vim.fn.stdpath('data') .. '/telescope-projects.txt'
 
+-- Checks if the file containing the list of project
+-- directories already exists.
+-- If it doesn't exist, it creates it.
 local function check_for_project_dirs_file()
   local f = io.open(project_dirs_file, "r")
   if f ~= nil then
@@ -28,6 +31,8 @@ local function check_for_project_dirs_file()
   end
 end
 
+-- Creates a Telescope `finder` based on the given options
+-- and list of projects
 local create_finder = function(opts, projects)
   local display_type = opts.display_type
   local widths = {
@@ -73,32 +78,6 @@ local create_finder = function(opts, projects)
     }
 end
 
--- local select_project = function(opts, projects)
---   local new_finder = project_finder(opts, projects)
-
---   pickers.new(opts, {
---     prompt_title = 'Select a project',
---     results_title = 'Projects',
---     finder = new_finder,
---     sorter = conf.file_sorter(opts),
---     attach_mappings = function(prompt_bufnr, map)
---       map('n', 'd', project_actions.delete_project)
---       map('n', 'r', project_actions.rename_project)
---       map('n', 'c', project_actions.add_project)
---       map('n', 'f', project_actions.find_project_files)
---       map('n', 'b', project_actions.browse_project_files)
---       map('n', 's', project_actions.search_in_project_files)
---       map('n', 'R', project_actions.recent_project_files)
---       map('n', 'w', project_actions.change_working_directory)
---       local on_project_selected = function()
---         project_actions.find_project_files(prompt_bufnr)
---       end
---       actions.select_default:replace(on_project_selected)
---       return true
---     end
---   }):find()
--- end
-
 local get_last_accessed_time = function(path)
   local expanded_path = vim.fn.expand(path)
   local fs_stat = vim.loop.fs_stat(expanded_path)
@@ -109,6 +88,8 @@ local get_last_accessed_time = function(path)
   end
 end
 
+-- Get information on all of the projects in the
+-- `project_dirs_file` and output it as a list
 local get_projects = function()
   check_for_project_dirs_file()
   local projects = {}
@@ -130,6 +111,10 @@ local get_projects = function()
   return projects
 end
 
+-- The main function.
+-- This creates a picker with a list of all of the projects,
+-- and attaches the appropriate mappings for associated
+-- actions.
 local project = function(opts)
   opts = opts or {}
 
@@ -143,7 +128,6 @@ local project = function(opts)
     sorter = conf.file_sorter(opts),
     attach_mappings = function(prompt_bufnr, map)
       local refresh_projects = function()
-        -- dump(action_state)
         local picker = action_state.get_current_picker(prompt_bufnr)
         picker:refresh(create_finder(opts,get_projects()), {reset_prompt=true})
       end

--- a/lua/telescope/_extensions/project_actions.lua
+++ b/lua/telescope/_extensions/project_actions.lua
@@ -10,6 +10,7 @@ function string.starts(String,Start)
    return string.sub(String,1,string.len(Start))==Start
 end
 
+-- Create a new project and add it to the list in the `project_dirs_file`
 project_actions.add_project = function(prompt_bufnr)
   local git_root = vim.fn.systemlist("git -C " .. vim.loop.cwd() .. " rev-parse --show-toplevel")[
     1
@@ -46,6 +47,8 @@ project_actions.add_project = function(prompt_bufnr)
   io.close(file)
 end
 
+-- Rename the selected project within the `project_dirs_file`.
+-- Uses a name provided by the user.
 project_actions.rename_project = function(prompt_bufnr)
   local oldName = actions.get_selected_entry(prompt_bufnr).ordinal
   local newName = vim.fn.input('Rename ' ..oldName.. ' to: ', oldName)
@@ -67,6 +70,7 @@ project_actions.rename_project = function(prompt_bufnr)
   print('Project renamed: ' .. actions.get_selected_entry(prompt_bufnr).ordinal .. ' -> ' .. newName)
 end
 
+-- Delete the selected project from the `project_dirs_file`
 project_actions.delete_project = function(prompt_bufnr)
   local newLines = ""
   for line in io.lines(project_dirs_file) do
@@ -84,6 +88,8 @@ project_actions.delete_project = function(prompt_bufnr)
   print('Project deleted: ' .. actions.get_selected_entry(prompt_bufnr).ordinal)
 end
 
+-- Find files within the selected project using the
+-- Telescope builtin `find_files`.
 project_actions.find_project_files = function(prompt_bufnr)
   local dir = actions.get_selected_entry(prompt_bufnr).value
   actions._close(prompt_bufnr, true)
@@ -91,6 +97,8 @@ project_actions.find_project_files = function(prompt_bufnr)
   builtin.find_files({cwd = dir})
 end
 
+-- Browse through files within the selected project using
+-- the Telescope builtin `file_browser`.
 project_actions.browse_project_files = function(prompt_bufnr)
   local dir = actions.get_selected_entry(prompt_bufnr).value
   actions._close(prompt_bufnr, true)
@@ -98,6 +106,8 @@ project_actions.browse_project_files = function(prompt_bufnr)
   builtin.file_browser({cwd = dir})
 end
 
+-- Search within files in the selected project using
+-- the Telescope builtin `live_grep`.
 project_actions.search_in_project_files = function(prompt_bufnr)
   local dir = actions.get_selected_entry(prompt_bufnr).value
   actions._close(prompt_bufnr, true)
@@ -105,6 +115,8 @@ project_actions.search_in_project_files = function(prompt_bufnr)
   builtin.live_grep({cwd = dir})
 end
 
+-- Search the recently used files within the selected project
+-- using the Telescope builtin `oldfiles`.
 project_actions.recent_project_files = function(prompt_bufnr)
   local dir = actions.get_selected_entry(prompt_bufnr).value
   actions._close(prompt_bufnr, true)
@@ -112,6 +124,7 @@ project_actions.recent_project_files = function(prompt_bufnr)
   builtin.oldfiles({cwd_only = true})
 end
 
+-- Change working directory to the selected project and close the picker.
 project_actions.change_working_directory = function(prompt_bufnr)
   local dir = actions.get_selected_entry(prompt_bufnr).value
   actions.close(prompt_bufnr)

--- a/lua/telescope/_extensions/project_actions.lua
+++ b/lua/telescope/_extensions/project_actions.lua
@@ -44,8 +44,6 @@ project_actions.add_project = function(prompt_bufnr)
     print('project added: ' .. project_title)
   end
   io.close(file)
-  actions.close(prompt_bufnr)
-  require 'telescope'.extensions.project.project()
 end
 
 project_actions.rename_project = function(prompt_bufnr)
@@ -67,8 +65,6 @@ project_actions.rename_project = function(prompt_bufnr)
   file:write(newLines)
   file:close()
   print('Project renamed: ' .. actions.get_selected_entry(prompt_bufnr).ordinal .. ' -> ' .. newName)
-  actions.close(prompt_bufnr)
-  require 'telescope'.extensions.project.project()
 end
 
 project_actions.delete_project = function(prompt_bufnr)
@@ -86,8 +82,6 @@ project_actions.delete_project = function(prompt_bufnr)
   file:write(newLines)
   file:close()
   print('Project deleted: ' .. actions.get_selected_entry(prompt_bufnr).ordinal)
-  actions.close(prompt_bufnr)
-  require 'telescope'.extensions.project.project()
 end
 
 project_actions.find_project_files = function(prompt_bufnr)


### PR DESCRIPTION
This PR reorganises the way that the `project` function is called by splitting parts of it into two separate functions
- `get_projects`: which collects all of the relevant information about projects listed in `project_dirs_file`
- `create_finder`: which creates a Telescope `finder` based on the given options and list of projects

This allows us to simplify the functions for the add/rename/delete actions and simply `enhance` those actions in the mappings.

Another added benefit, is that now we are not closing the picker, simply refreshing it, and we can keep all of the options provided by the user. So if a user has specified that they wanted the 'full' `display_type` and they wanted the window to be a particular size, this is retained on adding/renaming/deleting projects.