### PR TITLE
Fix errors in #35

### DIFF
--- a/lua/telescope/_extensions/project/finders.lua
+++ b/lua/telescope/_extensions/project/finders.lua
@@ -10,7 +10,7 @@ M.project_finder = function(opts, projects)
   local display_type = opts.display_type
   local widths = {
     title = 0,
-    dir = 0,
+    display_path = 0,
   }
 
   -- Loop over all of the projects and find the maximum length of
@@ -30,7 +30,7 @@ M.project_finder = function(opts, projects)
     separator = " ",
     items = {
       { width = widths.title },
-      { width = widths.dir },
+      { width = widths.display_path },
     }
   }
   local make_display = function(project)

--- a/lua/telescope/_extensions/project/finders.lua
+++ b/lua/telescope/_extensions/project/finders.lua
@@ -1,5 +1,5 @@
 local finders = require("telescope.finders")
-local utils = require("telescope.utils")
+local strings = require("plenary.strings")
 local entry_display = require("telescope.pickers.entry_display")
 
 local M = {}
@@ -22,7 +22,7 @@ M.project_finder = function(opts, projects)
       project.display_path = ''
     end
     for key, value in pairs(widths) do
-      widths[key] = math.max(value, utils.strdisplaywidth(project[key] or ''))
+      widths[key] = math.max(value, strings.strdisplaywidth(project[key] or ''))
     end
   end
 

--- a/lua/telescope/_extensions/project/git.lua
+++ b/lua/telescope/_extensions/project/git.lua
@@ -7,19 +7,19 @@ M.tmp_path = "/tmp/found_projects.txt"
 
 -- Find and store git repos if base_dir provided
 M.update_git_repos = function(base_dir, max_depth)
-  M.search_for_git_repos(base_dir, max_depth)
-  local git_projects = M.parse_git_repo_paths()
-  M.save_git_repos(git_projects)
+  if base_dir then
+    M.search_for_git_repos(base_dir, max_depth)
+    local git_projects = M.parse_git_repo_paths()
+    M.save_git_repos(git_projects)
+  end
 end
 
 -- Recurses directories under base directory to find all git projects
 M.search_for_git_repos = function(base_dir, max_depth)
-  if base_dir then
-    local max_depth_arg = " -maxdepth " .. max_depth
-    local find_args = " -type d -name .git -printf '%h\n'"
-    local shell_cmd = "find " .. base_dir .. max_depth_arg .. find_args
-    os.execute(shell_cmd .. " > " .. M.tmp_path)
-  end
+  local max_depth_arg = " -maxdepth " .. max_depth
+  local find_args = " -type d -name .git -printf '%h\n'"
+  local shell_cmd = "find " .. base_dir .. max_depth_arg .. find_args
+  os.execute(shell_cmd .. " > " .. M.tmp_path)
 end
 
 -- Reads tmp file, converting paths to projects


### PR DESCRIPTION
fixes #35

* switch to plenary.strings instead of telescope.utils
* fix mismatched keys between `widths.dir` and `project.display_path` (display_path seemed like the more descriptive key so I used that)
* fixes update_git_repos trying to parse `/tmp/found_projects.txt` when we had just skipped creating it