### PR TITLE
feat: handle missing project paths

### DIFF
--- a/lua/telescope/_extensions/project/main.lua
+++ b/lua/telescope/_extensions/project/main.lua
@@ -16,7 +16,8 @@ local M = {}
 local base_dir
 local max_depth
 
--- Allow user to set base_dir in setup
+-- Setup function sets variables, cleans up missing projects,
+-- and updates projects via git project scanner
 M.setup = function(setup_config)
   base_dir = setup_config.base_dir or nil
   max_depth = setup_config.max_depth or 3

--- a/lua/telescope/_extensions/project/main.lua
+++ b/lua/telescope/_extensions/project/main.lua
@@ -20,6 +20,7 @@ local max_depth
 M.setup = function(setup_config)
   base_dir = setup_config.base_dir or nil
   max_depth = setup_config.max_depth or 3
+  _utils.cleanup_missing_projects()
   _git.update_git_repos(base_dir, max_depth)
 end
 

--- a/lua/telescope/_extensions/project/utils.lua
+++ b/lua/telescope/_extensions/project/utils.lua
@@ -1,3 +1,5 @@
+local Path = require('plenary.path')
+
 local M = {}
 
 -- The file path to telescope projects
@@ -5,7 +7,7 @@ M.telescope_projects_file = vim.fn.stdpath('data') .. '/telescope-projects.txt'
 
 -- Initialize file if does not exist
 M.init_file = function()
-  local file_path = require'plenary'.path:new(M.telescope_projects_file)
+  local file_path = Path:new(M.telescope_projects_file)
   if not file_path:exists() then
     file_path:touch()
   end
@@ -79,6 +81,17 @@ end
 M.store_project = function(file, project)
   local line = project.title .. "=" .. project.path .. "=" .. project.activated .. "\n"
   file:write(line)
+end
+
+-- Remove project entries if they no longer exist in file system
+M.cleanup_missing_projects = function()
+  local file = io.open(M.telescope_projects_file, "w")
+  for _, project in pairs(M.get_project_objects()) do
+    if Path:new(project.path):exists() then
+      M.store_project(file, project)
+    end
+  end
+  io.close(file)
 end
 
 -- Trim whitespace for strings

--- a/lua/telescope/_extensions/project/utils.lua
+++ b/lua/telescope/_extensions/project/utils.lua
@@ -17,8 +17,9 @@ end
 M.get_projects = function()
   local filtered_projects = {}
   for _, project in pairs(M.get_project_objects()) do
+    local path_exists = Path:new(project.path):exists()
     local is_activated = tonumber(project.activated) == 1
-    if is_activated then
+    if path_exists and is_activated then
       table.insert(filtered_projects, project)
     end
   end

--- a/lua/tests/utils_spec.lua
+++ b/lua/tests/utils_spec.lua
@@ -56,8 +56,23 @@ describe("utils", function()
           found_test_project = true
         end
       end
-
       assert.equal(true, found_test_project)
+
+      -- remove example project and run cleanup
+      path:new(example_project_path):rm()
+      utils.cleanup_missing_projects()
+
+      -- recheck that example project was not found now that it is gone
+      projects = utils.get_projects()
+      found_test_project = false
+      for _, stored_project in pairs(projects) do
+        if stored_project.path == example_project_path then
+          found_test_project = true
+        end
+      end
+      assert.equal(false, found_test_project)
+
+      -- cleanup
       test_projects_path:rm()
     end)
 


### PR DESCRIPTION
# Motivation

Projects that do not exist anymore on the system should not be displayed in `projects` picker.

# Solution

Add a `cleanup_missing_projects` utility that will run at setup (each time neovim session is started) which will remove projects from `telescope-projects.txt` where the file path does not exist in file system. Also during a given session, filter out projects whose paths' do not exist.