### PR TITLE
feat: label project paths that do not exist

### DIFF
--- a/lua/telescope/_extensions/project/actions.lua
+++ b/lua/telescope/_extensions/project/actions.lua
@@ -81,8 +81,8 @@ end
 M.find_project_files = function(prompt_bufnr)
   local project_path = M.get_selected_path(prompt_bufnr)
   actions._close(prompt_bufnr, true)
-  vim.fn.execute("cd " .. project_path, "silent")
-  builtin.find_files({cwd = project_path})
+  local cd_successful = _utils.change_project_dir(project_path)
+  if cd_successful then builtin.find_files({cwd = project_path}) end
 end
 
 -- Browse through files within the selected project using
@@ -90,8 +90,8 @@ end
 M.browse_project_files = function(prompt_bufnr)
   local project_path = M.get_selected_path(prompt_bufnr)
   actions._close(prompt_bufnr, true)
-  vim.fn.execute("cd " .. project_path, "silent")
-  builtin.file_browser({cwd = project_path})
+  local cd_successful = _utils.change_project_dir(project_path)
+  if cd_successful then builtin.file_browser({cwd = project_path}) end
 end
 
 -- Search within files in the selected project using
@@ -99,8 +99,8 @@ end
 M.search_in_project_files = function(prompt_bufnr)
   local project_path = M.get_selected_path(prompt_bufnr)
   actions._close(prompt_bufnr, true)
-  vim.fn.execute("cd " .. project_path, "silent")
-  builtin.live_grep({cwd = project_path})
+  local cd_successful = _utils.change_project_dir(project_path)
+  if cd_successful then builtin.live_grep({cwd = project_path}) end
 end
 
 -- Search the recently used files within the selected project
@@ -108,15 +108,15 @@ end
 M.recent_project_files = function(prompt_bufnr)
   local project_path = M.get_selected_path(prompt_bufnr)
   actions._close(prompt_bufnr, true)
-  vim.fn.execute("cd " .. project_path, "silent")
-  builtin.oldfiles({cwd_only = true})
+  local cd_successful = _utils.change_project_dir(project_path)
+  if cd_successful then builtin.oldfiles({cwd_only = true}) end
 end
 
 -- Change working directory to the selected project and close the picker.
 M.change_working_directory = function(prompt_bufnr)
   local project_path = M.get_selected_path(prompt_bufnr)
   actions.close(prompt_bufnr)
-  vim.fn.execute("cd " .. project_path, "silent")
+  _utils.change_project_dir(project_path)
 end
 
 return transform_mod(M)

--- a/lua/telescope/_extensions/project/actions.lua
+++ b/lua/telescope/_extensions/project/actions.lua
@@ -43,13 +43,14 @@ end
 
 -- Rename the selected project within the `telescope_projects_file`.
 M.rename_project = function(prompt_bufnr)
+  local selected_path = M.get_selected_path(prompt_bufnr)
   local selected_title = M.get_selected_title(prompt_bufnr)
   local new_title = vim.fn.input('Rename ' ..selected_title.. ' to: ', selected_title)
   local projects = _utils.get_project_objects()
 
   local file = io.open(_utils.telescope_projects_file, "w")
   for _, project in pairs(projects) do
-    if project.title == selected_title then
+    if project.path == selected_path then
       project.title = new_title
     end
     _utils.store_project(file, project)
@@ -61,61 +62,61 @@ end
 -- Delete (deactivate) the selected project from the `telescope_projects_file`
 M.delete_project = function(prompt_bufnr)
   local projects = _utils.get_project_objects()
-  local selected_title = M.get_selected_title(prompt_bufnr)
+  local selected_path = M.get_selected_path(prompt_bufnr)
 
   local file = io.open(_utils.telescope_projects_file, "w")
   for _, project in pairs(projects) do
-    if project.title == selected_title then
+    if project.path == selected_path then
       project.activated = 0
     end
     _utils.store_project(file, project)
   end
 
   io.close(file)
-  print('Project deleted: ' .. selected_title)
+  print('Project deleted: ' .. selected_path)
 end
 
 -- Find files within the selected project using the
 -- Telescope builtin `find_files`.
 M.find_project_files = function(prompt_bufnr)
-  local dir = actions.get_selected_entry(prompt_bufnr).value
+  local project_path = M.get_selected_path(prompt_bufnr)
   actions._close(prompt_bufnr, true)
-  vim.fn.execute("cd " .. dir, "silent")
-  builtin.find_files({cwd = dir})
+  vim.fn.execute("cd " .. project_path, "silent")
+  builtin.find_files({cwd = project_path})
 end
 
 -- Browse through files within the selected project using
 -- the Telescope builtin `file_browser`.
 M.browse_project_files = function(prompt_bufnr)
-  local dir = actions.get_selected_entry(prompt_bufnr).value
+  local project_path = M.get_selected_path(prompt_bufnr)
   actions._close(prompt_bufnr, true)
-  vim.fn.execute("cd " .. dir, "silent")
-  builtin.file_browser({cwd = dir})
+  vim.fn.execute("cd " .. project_path, "silent")
+  builtin.file_browser({cwd = project_path})
 end
 
 -- Search within files in the selected project using
 -- the Telescope builtin `live_grep`.
 M.search_in_project_files = function(prompt_bufnr)
-  local dir = actions.get_selected_entry(prompt_bufnr).value
+  local project_path = M.get_selected_path(prompt_bufnr)
   actions._close(prompt_bufnr, true)
-  vim.fn.execute("cd " .. dir, "silent")
-  builtin.live_grep({cwd = dir})
+  vim.fn.execute("cd " .. project_path, "silent")
+  builtin.live_grep({cwd = project_path})
 end
 
 -- Search the recently used files within the selected project
 -- using the Telescope builtin `oldfiles`.
 M.recent_project_files = function(prompt_bufnr)
-  local dir = actions.get_selected_entry(prompt_bufnr).value
+  local project_path = M.get_selected_path(prompt_bufnr)
   actions._close(prompt_bufnr, true)
-  vim.fn.execute("cd " .. dir, "silent")
+  vim.fn.execute("cd " .. project_path, "silent")
   builtin.oldfiles({cwd_only = true})
 end
 
 -- Change working directory to the selected project and close the picker.
 M.change_working_directory = function(prompt_bufnr)
-  local dir = actions.get_selected_entry(prompt_bufnr).value
+  local project_path = M.get_selected_path(prompt_bufnr)
   actions.close(prompt_bufnr)
-  vim.fn.execute("cd " .. dir, "silent")
+  vim.fn.execute("cd " .. project_path, "silent")
 end
 
 return transform_mod(M)

--- a/lua/telescope/_extensions/project/finders.lua
+++ b/lua/telescope/_extensions/project/finders.lua
@@ -1,4 +1,5 @@
 local finders = require("telescope.finders")
+local Path = require('plenary.path')
 local strings = require("plenary.strings")
 local entry_display = require("telescope.pickers.entry_display")
 
@@ -20,6 +21,10 @@ M.project_finder = function(opts, projects)
       project.display_path = '[' .. project.path .. ']'
     else
       project.display_path = ''
+    end
+    local project_path_exists = Path:new(project.path):exists()
+    if not project_path_exists then
+      project.title = project.title .. " [deleted]"
     end
     for key, value in pairs(widths) do
       widths[key] = math.max(value, strings.strdisplaywidth(project[key] or ''))

--- a/lua/telescope/_extensions/project/main.lua
+++ b/lua/telescope/_extensions/project/main.lua
@@ -16,7 +16,7 @@ local M = {}
 local base_dir
 local max_depth
 
--- Allow user to set base_dir in setup
+-- Allow user to set base_dir and max_depth in setup
 M.setup = function(setup_config)
   base_dir = setup_config.base_dir or nil
   max_depth = setup_config.max_depth or 3

--- a/lua/telescope/_extensions/project/main.lua
+++ b/lua/telescope/_extensions/project/main.lua
@@ -16,12 +16,10 @@ local M = {}
 local base_dir
 local max_depth
 
--- Setup function sets variables, cleans up missing projects,
--- and updates projects via git project scanner
+-- Allow user to set base_dir in setup
 M.setup = function(setup_config)
   base_dir = setup_config.base_dir or nil
   max_depth = setup_config.max_depth or 3
-  _utils.cleanup_missing_projects()
   _git.update_git_repos(base_dir, max_depth)
 end
 

--- a/lua/telescope/_extensions/project/utils.lua
+++ b/lua/telescope/_extensions/project/utils.lua
@@ -98,8 +98,20 @@ M.has_value = function(tbl, val)
   return false
 end
 
+-- Check that string starts with given value
 M.string_starts_with = function(text, start)
    return string.sub(text, 1, string.len(start)) == start
+end
+
+-- Change directory only when path exists
+M.change_project_dir = function(project_path)
+  if Path:new(project_path):exists() then
+    vim.fn.execute("cd " .. project_path, "silent")
+    return true
+  else
+    print("The path '" .. project_path .. "' does not exist")
+    return false
+  end
 end
 
 return M

--- a/lua/telescope/_extensions/project/utils.lua
+++ b/lua/telescope/_extensions/project/utils.lua
@@ -1,5 +1,3 @@
-local Path = require('plenary.path')
-
 local M = {}
 
 -- The file path to telescope projects
@@ -7,7 +5,7 @@ M.telescope_projects_file = vim.fn.stdpath('data') .. '/telescope-projects.txt'
 
 -- Initialize file if does not exist
 M.init_file = function()
-  local file_path = Path:new(M.telescope_projects_file)
+  local file_path = require'plenary'.path:new(M.telescope_projects_file)
   if not file_path:exists() then
     file_path:touch()
   end
@@ -17,9 +15,8 @@ end
 M.get_projects = function()
   local filtered_projects = {}
   for _, project in pairs(M.get_project_objects()) do
-    local path_exists = Path:new(project.path):exists()
     local is_activated = tonumber(project.activated) == 1
-    if path_exists and is_activated then
+    if is_activated then
       table.insert(filtered_projects, project)
     end
   end
@@ -82,17 +79,6 @@ end
 M.store_project = function(file, project)
   local line = project.title .. "=" .. project.path .. "=" .. project.activated .. "\n"
   file:write(line)
-end
-
--- Remove project entries if they no longer exist in file system
-M.cleanup_missing_projects = function()
-  local file = io.open(M.telescope_projects_file, "w")
-  for _, project in pairs(M.get_project_objects()) do
-    if Path:new(project.path):exists() then
-      M.store_project(file, project)
-    end
-  end
-  io.close(file)
 end
 
 -- Trim whitespace for strings

--- a/lua/telescope/_extensions/project/utils.lua
+++ b/lua/telescope/_extensions/project/utils.lua
@@ -17,9 +17,8 @@ end
 M.get_projects = function()
   local filtered_projects = {}
   for _, project in pairs(M.get_project_objects()) do
-    local path_exists = Path:new(project.path):exists()
     local is_activated = tonumber(project.activated) == 1
-    if path_exists and is_activated then
+    if is_activated then
       table.insert(filtered_projects, project)
     end
   end

--- a/lua/telescope/_extensions/project/utils.lua
+++ b/lua/telescope/_extensions/project/utils.lua
@@ -1,3 +1,5 @@
+local Path = require('plenary.path')
+
 local M = {}
 
 -- The file path to telescope projects
@@ -5,7 +7,7 @@ M.telescope_projects_file = vim.fn.stdpath('data') .. '/telescope-projects.txt'
 
 -- Initialize file if does not exist
 M.init_file = function()
-  local file_path = require'plenary'.path:new(M.telescope_projects_file)
+  local file_path = Path:new(M.telescope_projects_file)
   if not file_path:exists() then
     file_path:touch()
   end
@@ -15,8 +17,9 @@ end
 M.get_projects = function()
   local filtered_projects = {}
   for _, project in pairs(M.get_project_objects()) do
+    local path_exists = Path:new(project.path):exists()
     local is_activated = tonumber(project.activated) == 1
-    if is_activated then
+    if path_exists and is_activated then
       table.insert(filtered_projects, project)
     end
   end

--- a/lua/tests/utils_spec.lua
+++ b/lua/tests/utils_spec.lua
@@ -56,23 +56,8 @@ describe("utils", function()
           found_test_project = true
         end
       end
+
       assert.equal(true, found_test_project)
-
-      -- remove example project and run cleanup
-      path:new(example_project_path):rm()
-      utils.cleanup_missing_projects()
-
-      -- recheck that example project was not found now that it is gone
-      projects = utils.get_projects()
-      found_test_project = false
-      for _, stored_project in pairs(projects) do
-        if stored_project.path == example_project_path then
-          found_test_project = true
-        end
-      end
-      assert.equal(false, found_test_project)
-
-      -- cleanup
       test_projects_path:rm()
     end)
 

--- a/lua/tests/utils_spec.lua
+++ b/lua/tests/utils_spec.lua
@@ -24,6 +24,14 @@ describe("utils", function()
       assert.equal(false, utils.has_value(paths, "/projects/C"))
     end)
 
+    it ("change project directory works", function()
+      local test_dir = path:new("/tmp/test_dir")
+      test_dir:mkdir()
+      assert.equal(true, utils.change_project_dir(test_dir.filename))
+      test_dir:rmdir()
+      assert.equal(false, utils.change_project_dir(test_dir.filename))
+    end)
+
   end)
 
   describe("project", function()


### PR DESCRIPTION
Hi @claidler as we discussed in #37 this is a safer approach to filtering out projects that do not exist on file system.

The last attempt, I tried to modify the underlying file, but that had unintentional consequences. Hopefully this implementation does what it is supposed to do. I tested it with the test case that you described in #37 and it worked fine. 

Please have a look when you have a chance 🙂