### PR TITLE
Close file handle after saving projects

### DIFF
--- a/lua/telescope/_extensions/project/git.lua
+++ b/lua/telescope/_extensions/project/git.lua
@@ -43,6 +43,7 @@ M.save_git_repos = function(git_projects)
       _utils.store_project(file, project)
     end
   end
+  file:close()
 end
 
 -- Attempt to locate git directory, else return cwd


### PR DESCRIPTION
This fixes an issue where auto-discovered projects don't show
up in the projects list the very first time the project function
is run.