### PR TITLE
Show hidden files in selected project

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ lua require'telescope'.extensions.project.project{ display_type = 'full' }
 
 ## Available setup settings:
 
-| Keys        | Description                                      | Options                |
-|-------------|--------------------------------------------------|------------------------|
-| `base_dirs` | Array of project base directory configurations   | table (default: nil)   |
+| Keys           | Description                                                   | Options                |
+|----------------|---------------------------------------------------------------|------------------------|
+| `base_dirs`    | Array of project base directory configurations                | table (default: nil)   |
+| `hidden_files` | Show hidden files in selected project                         | bool (default: false)  |
 
 Setup settings can be added when requiring telescope, as shown below:  
 
@@ -95,7 +96,8 @@ require('telescope').setup {
         {'~/dev/src2'},
         {'~/dev/src3', max_depth = 4},
         {path = '~/dev/src4'},
-        {path = '~/dev/src5', max_depth = 2}
+        {path = '~/dev/src5', max_depth = 2},
+        hidden_files = true -- default: false
       }
   }
 }

--- a/lua/telescope/_extensions/project/actions.lua
+++ b/lua/telescope/_extensions/project/actions.lua
@@ -78,11 +78,11 @@ end
 
 -- Find files within the selected project using the
 -- Telescope builtin `find_files`.
-M.find_project_files = function(prompt_bufnr)
+M.find_project_files = function(prompt_bufnr, hidden_files)
   local project_path = M.get_selected_path(prompt_bufnr)
   actions._close(prompt_bufnr, true)
   local cd_successful = _utils.change_project_dir(project_path)
-  if cd_successful then builtin.find_files({cwd = project_path}) end
+  if cd_successful then builtin.find_files({cwd = project_path, hidden = hidden_files}) end
 end
 
 -- Browse through files within the selected project using

--- a/lua/telescope/_extensions/project/main.lua
+++ b/lua/telescope/_extensions/project/main.lua
@@ -14,6 +14,7 @@ local M = {}
 
 -- Variables that setup can change
 local base_dirs
+local hidden_files
 
 -- Allow user to set base_dirs
 M.setup = function(setup_config)
@@ -23,6 +24,7 @@ M.setup = function(setup_config)
   end
 
   base_dirs = setup_config.base_dirs or nil
+  hidden_files = setup_config.hidden_files or false
   _git.update_git_repos(base_dirs)
 end
 
@@ -64,7 +66,7 @@ M.project = function(opts)
       map('i', '<c-w>', _actions.change_working_directory)
 
       local on_project_selected = function()
-        _actions.find_project_files(prompt_bufnr)
+        _actions.find_project_files(prompt_bufnr, hidden_files)
       end
       actions.select_default:replace(on_project_selected)
       return true


### PR DESCRIPTION
Hello,
I missed having option to see hidden files in projects. Especially in my `dotfiles` repo.
This adds ability to toggle hidden files in `find_files` builtin using `hidden_files` variable from `setup`.