### PR TITLE
feat: readme preview

### DIFF
--- a/lua/telescope/_extensions/project/main.lua
+++ b/lua/telescope/_extensions/project/main.lua
@@ -16,6 +16,7 @@ local M = {}
 -- Variables that setup can change
 local base_dirs
 local hidden_files
+local preview
 
 -- Allow user to set base_dirs
 M.setup = function(setup_config)
@@ -26,12 +27,15 @@ M.setup = function(setup_config)
 
   base_dirs = setup_config.base_dirs or nil
   hidden_files = setup_config.hidden_files or false
+  preview = setup_config.preview or {}
   _git.update_git_repos(base_dirs)
 end
 
 -- This creates a picker with a list of all of the projects
 M.project = function(opts)
-  pickers.new(opts or {}, {
+  opts = opts or {}
+  opts.preview = preview
+  pickers.new(opts, {
     prompt_title = 'Select a project',
     results_title = 'Projects',
     finder = _finders.project_finder(opts, _utils.get_projects()),

--- a/lua/telescope/_extensions/project/main.lua
+++ b/lua/telescope/_extensions/project/main.lua
@@ -3,6 +3,7 @@ local actions = require("telescope.actions")
 local action_state = require("telescope.actions.state")
 local pickers = require("telescope.pickers")
 local conf = require("telescope.config").values
+local previewers = require("telescope._extensions.project.previewer")
 
 -- telescope-project modules
 local _actions = require("telescope._extensions.project.actions")
@@ -35,6 +36,7 @@ M.project = function(opts)
     results_title = 'Projects',
     finder = _finders.project_finder(opts, _utils.get_projects()),
     sorter = conf.file_sorter(opts),
+    previewer = previewers.previewer.new(opts),
     attach_mappings = function(prompt_bufnr, map)
 
       local refresh_projects = function()

--- a/lua/telescope/_extensions/project/previewer.lua
+++ b/lua/telescope/_extensions/project/previewer.lua
@@ -1,0 +1,41 @@
+local previewers = require("telescope.previewers")
+local utils = require('telescope.utils')
+local defaulter = utils.make_default_callable
+
+local M = {}
+
+local function file_exists(name)
+    local f = io.open(name,"r")
+    if f ~= nil then io.close(f) return true else return false end
+end
+
+M.previewer = defaulter(function(_)
+    return previewers.new_buffer_previewer({
+        title = "Preview",
+        define_preview = function(self, entry, opts)
+            -- Get the README or notes files, defaulting to displaying the folder
+            local path = entry.path
+            local default_readme_files = {
+                "README.md",
+                "README.txt",
+                "readme.md",
+                "readme.txt",
+                "notes.md",
+                "notes.txt"
+            }
+
+            for _, f in pairs(default_readme_files) do
+                local f_path = entry.path .. "/" .. f
+                if file_exists(f_path) then
+                    path = f_path
+                end
+            end
+
+            -- Return the previewer
+            return previewers.buffer_previewer_maker(path, self.state.bufnr, opts)
+        end
+    })
+end, {})
+
+return M
+

--- a/lua/telescope/_extensions/project/previewer.lua
+++ b/lua/telescope/_extensions/project/previewer.lua
@@ -9,25 +9,34 @@ local function file_exists(name)
     if f ~= nil then io.close(f) return true else return false end
 end
 
-M.previewer = defaulter(function(_)
+M.previewer = defaulter(function(user_opts)
+    if user_opts.preview.disable == true then
+        return nil
+    end
     return previewers.new_buffer_previewer({
         title = "Preview",
         define_preview = function(self, entry, opts)
             -- Get the README or notes files, defaulting to displaying the folder
             local path = entry.path
-            local default_readme_files = {
-                "README.md",
-                "README.txt",
-                "readme.md",
-                "readme.txt",
-                "notes.md",
-                "notes.txt"
-            }
+            if user_opts.preview.dir_only == nil or user_opts.preview.dir_only == false then
+                local default_readme_files = {
+                    "README.md",
+                    "README.txt",
+                    "readme.md",
+                    "readme.txt",
+                }
+                local readme_files = default_readme_files
+                if user_opts.preview.additional_readmes then
+                    readme_files = table.merge(default_readme_files, user_opts.preview.additional_readmes)
+                end
 
-            for _, f in pairs(default_readme_files) do
-                local f_path = entry.path .. "/" .. f
-                if file_exists(f_path) then
-                    path = f_path
+
+                for _, f in pairs(readme_files) do
+                    local f_path = entry.path .. "/" .. f
+                    if file_exists(f_path) then
+                        path = f_path
+                        break
+                    end
                 end
             end
 


### PR DESCRIPTION
Hi there !

Just a small PR to add the possibility to have a preview of the projects while browsing them.
The preview shows the directory if no readme was found, and shows the readme if any from `readme.{md,txt}` and `README.{md,txt}`.

Here is a little demo: 

![telescope_project_demo](https://user-images.githubusercontent.com/43273245/130691709-ac0ecb3f-7162-489e-b26f-20c70debd55c.gif)

Some configuration options have been added to configure this feature :

```lua
require("telescope").setup {
    extensions = {
        project = {
            preview = {
                disable = false, -- default
                dir_only = false, -- default
                additional_readmes = {"notes.md", "notes.txt"} -- not default
            }
        }
    }
}
```

Thanks !