### PR TITLE
fix: don't use deprecated actions

### DIFF
--- a/lua/telescope/_extensions/project/actions.lua
+++ b/lua/telescope/_extensions/project/actions.lua
@@ -1,5 +1,6 @@
 local builtin = require("telescope.builtin")
 local actions = require("telescope.actions")
+local actions_state = require("telescope.actions.state")
 local transform_mod = require('telescope.actions.mt').transform_mod
 
 local _git = require("telescope._extensions.project.git")
@@ -9,12 +10,12 @@ local M = {}
 
 -- Extracts project title from current buffer selection
 M.get_selected_title = function(prompt_bufnr)
-  return actions.get_selected_entry(prompt_bufnr).ordinal
+  return actions_state.get_selected_entry(prompt_bufnr).ordinal
 end
 
 -- Extracts project path from current buffer selection
 M.get_selected_path = function(prompt_bufnr)
-  return actions.get_selected_entry(prompt_bufnr).value
+  return actions_state.get_selected_entry(prompt_bufnr).value
 end
 
 -- Create a new project and add it to the list in the `telescope_projects_file`


### PR DESCRIPTION
We currently use `telescope.actions.get_selected_entry` in our internal actions.
This is deprecated in favour of `telescope.actions.state.get_selected_entry`, causing a logging message every time a project is selected.

This PR switches to the new functions.