### PR TITLE
feat: default-finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,11 @@ lua require'telescope'.extensions.project.project{ display_type = 'full' }
 
 ## Available setup settings:
 
-| Keys           | Description                                                   | Options                |
-|----------------|---------------------------------------------------------------|------------------------|
-| `base_dirs`    | Array of project base directory configurations                | table (default: nil)   |
-| `hidden_files` | Show hidden files in selected project                         | bool (default: false)  |
+| Keys                | Description                                        | Options                |
+|---------------------|----------------------------------------------------|------------------------|
+| `base_dirs`         | Array of project base directory configurations     | table (default: nil)   |
+| `hidden_files`      | Show hidden files in selected project              | bool (default: false)  |
+| `browse_by_default` | Open file-browser instead of find-files by default | bool (default: false)  |
 
 Setup settings can be added when requiring telescope, as shown below:
 
@@ -104,7 +105,9 @@ require('telescope').setup {
         {path = '~/dev/src4'},
         {path = '~/dev/src5', max_depth = 2},
       },
-      hidden_files = true -- default: false
+      hidden_files = true, -- default: false
+      browse_by_default = true, -- default: false
+    }
   }
 }
 ```

--- a/lua/telescope/_extensions/project/main.lua
+++ b/lua/telescope/_extensions/project/main.lua
@@ -15,6 +15,7 @@ local M = {}
 -- Variables that setup can change
 local base_dirs
 local hidden_files
+local browse_by_default
 
 -- Allow user to set base_dirs
 M.setup = function(setup_config)
@@ -25,6 +26,7 @@ M.setup = function(setup_config)
 
   base_dirs = setup_config.base_dirs or nil
   hidden_files = setup_config.hidden_files or false
+  browse_by_default = setup_config.browse_by_default or nil
   _git.update_git_repos(base_dirs)
 end
 
@@ -70,7 +72,11 @@ M.project = function(opts)
       map('i', '<c-w>', _actions.change_workspace)
 
       local on_project_selected = function()
-        _actions.find_project_files(prompt_bufnr, hidden_files)
+        if browse_by_default then
+          _actions.browse_project_files(prompt_bufnr, hidden_files)
+        else
+          _actions.find_project_files(prompt_bufnr, hidden_files)
+        end
       end
       actions.select_default:replace(on_project_selected)
       return true


### PR DESCRIPTION
The setting `browse_by_default` allows users to choose the default finder between `file-browser` and `find-files`.