### PR TITLE
Configurable scope for project directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,11 @@ lua require'telescope'.extensions.project.project{ display_type = 'full' }
 
 ## Available setup settings:
 
-| Keys           | Description                                                   | Options                |
-|----------------|---------------------------------------------------------------|------------------------|
-| `base_dirs`    | Array of project base directory configurations                | table (default: nil)   |
-| `hidden_files` | Show hidden files in selected project                         | bool (default: false)  |
+| Keys           | Description                                                   | Options                     |
+|----------------|---------------------------------------------------------------|-----------------------------|
+| `base_dirs`    | Array of project base directory configurations                | table (default: nil)        |
+| `hidden_files` | Show hidden files in selected project                         | bool (default: false)       |
+| `cwd_scope`    | Change directory for the window, tab or local buffer          | string (default: "window")  |
 
 Setup settings can be added when requiring telescope, as shown below:
 
@@ -110,6 +111,7 @@ require('telescope').setup {
         {path = '~/dev/src5', max_depth = 2},
       },
       hidden_files = true, -- default: false
+      cwd_scope = "tab",   -- default: window
       theme = "dropdown"
   }
 }

--- a/lua/telescope/_extensions/project/actions.lua
+++ b/lua/telescope/_extensions/project/actions.lua
@@ -97,10 +97,10 @@ end
 
 -- Find files within the selected project using the
 -- Telescope builtin `find_files`.
-M.find_project_files = function(prompt_bufnr, hidden_files)
+M.find_project_files = function(prompt_bufnr, hidden_files, cwd_scope)
   local project_path = M.get_selected_path(prompt_bufnr)
   actions._close(prompt_bufnr, true)
-  local cd_successful = _utils.change_project_dir(project_path)
+  local cd_successful = _utils.change_project_dir(project_path, cwd_scope)
   if cd_successful then
     vim.schedule(function()
       builtin.find_files({cwd = project_path, hidden = hidden_files})
@@ -118,7 +118,7 @@ M.browse_project_files = function(prompt_bufnr)
   end
   local project_path = M.get_selected_path(prompt_bufnr)
   actions._close(prompt_bufnr, true)
-  local cd_successful = _utils.change_project_dir(project_path)
+  local cd_successful = _utils.change_project_dir(project_path, "local")
   if cd_successful then
     vim.schedule(function()
       file_browser.exports.file_browser({ cwd = project_path })
@@ -131,7 +131,7 @@ end
 M.search_in_project_files = function(prompt_bufnr)
   local project_path = M.get_selected_path(prompt_bufnr)
   actions._close(prompt_bufnr, true)
-  local cd_successful = _utils.change_project_dir(project_path)
+  local cd_successful = _utils.change_project_dir(project_path, "local")
   if cd_successful then
     vim.schedule(function()
       builtin.live_grep({cwd = project_path})
@@ -144,7 +144,7 @@ end
 M.recent_project_files = function(prompt_bufnr)
   local project_path = M.get_selected_path(prompt_bufnr)
   actions._close(prompt_bufnr, true)
-  local cd_successful = _utils.change_project_dir(project_path)
+  local cd_successful = _utils.change_project_dir(project_path, "local")
   if cd_successful then
     vim.schedule(function()
       builtin.oldfiles({cwd_only = true})
@@ -156,7 +156,7 @@ end
 M.change_working_directory = function(prompt_bufnr)
   local project_path = M.get_selected_path(prompt_bufnr)
   actions.close(prompt_bufnr)
-  _utils.change_project_dir(project_path)
+  _utils.change_project_dir(project_path, "window")
 end
 
 return transform_mod(M)

--- a/lua/telescope/_extensions/project/main.lua
+++ b/lua/telescope/_extensions/project/main.lua
@@ -16,6 +16,7 @@ local M = {}
 -- Variables that setup can change
 local base_dirs
 local hidden_files
+local cwd_scope
 
 -- Allow user to set base_dirs
 local theme_opts = {}
@@ -31,6 +32,7 @@ M.setup = function(setup_config)
 
   base_dirs = setup_config.base_dirs or nil
   hidden_files = setup_config.hidden_files or false
+  cwd_scope = setup_config.cwd_scope or "window"
   _git.update_git_repos(base_dirs)
 end
 
@@ -77,7 +79,7 @@ M.project = function(opts)
       map('i', '<c-w>', _actions.change_workspace)
 
       local on_project_selected = function()
-        _actions.find_project_files(prompt_bufnr, hidden_files)
+        _actions.find_project_files(prompt_bufnr, hidden_files, cwd_scope)
       end
       actions.select_default:replace(on_project_selected)
       return true

--- a/lua/telescope/_extensions/project/utils.lua
+++ b/lua/telescope/_extensions/project/utils.lua
@@ -117,9 +117,14 @@ M.string_starts_with = function(text, start)
 end
 
 -- Change directory only when path exists
-M.change_project_dir = function(project_path)
+M.change_project_dir = function(project_path, scope)
+  local cd = "cd"
+  if     scope == "local" then cd = "lcd"
+  elseif scope == "tab" then   cd = "tcd"
+  end
+
   if Path:new(project_path):exists() then
-    vim.fn.execute("cd " .. project_path, "silent")
+    vim.fn.execute(cd .. " " .. project_path, "silent")
     return true
   else
     print("The path '" .. project_path .. "' does not exist")

--- a/lua/tests/utils_spec.lua
+++ b/lua/tests/utils_spec.lua
@@ -28,8 +28,33 @@ describe("utils", function()
       local test_dir = path:new("/tmp/test_dir")
       test_dir:mkdir()
       assert.equal(true, utils.change_project_dir(test_dir.filename))
+      assert.equal(0, vim.api.nvim_call_function("haslocaldir", {1}))
       test_dir:rmdir()
       assert.equal(false, utils.change_project_dir(test_dir.filename))
+    end)
+
+    it ("local project directory works", function()
+      local test_dir = path:new("/tmp/test_dir")
+      test_dir:mkdir()
+      assert.equal(0, vim.api.nvim_call_function("haslocaldir", {1}))
+      assert.equal(true, utils.change_project_dir(test_dir.filename, "local"))
+      assert.equal(1, vim.api.nvim_call_function("haslocaldir", {1}))
+      test_dir:rmdir()
+
+      -- Reset cwd
+      vim.fn.execute("cd")
+    end)
+
+    it ("tab project directory works", function()
+      local test_dir = path:new("/tmp/test_dir")
+      test_dir:mkdir()
+      assert.equal(0, vim.api.nvim_call_function("haslocaldir", {1}))
+      assert.equal(true, utils.change_project_dir(test_dir.filename, "tab"))
+      assert.equal(1, vim.api.nvim_call_function("haslocaldir", {1, 1}))
+      test_dir:rmdir()
+
+      -- Reset cwd
+      vim.fn.execute("cd")
     end)
 
   end)


### PR DESCRIPTION
Resolves #61 

I _think_ the default behaviour of this should be roughly the same as before but without the surprise `$CWD` changes, additionally there is an optional flag to scope switching to a project to the current tab.

Feedback welcome :pray: 