### PR TITLE
Use `gsub` to remove ansi-rgb term output after getting `git_root` from `vim.fn.systemlist`

### DIFF
--- a/lua/telescope/_extensions/project/git.lua
+++ b/lua/telescope/_extensions/project/git.lua
@@ -55,12 +55,12 @@ end
 
 -- Attempt to locate git directory, else return cwd
 M.try_and_find_git_path = function()
-  local git_cmd = "git -C " .. vim.fn.fnameescape(vim.loop.cwd()) .. " rev-parse --show-toplevel"
+  local git_cmd = "git -C " .. vim.loop.cwd() .. " rev-parse --show-toplevel"
   local git_root = tostring(vim.fn.systemlist(git_cmd)[1]):gsub(".*","")
   local git_root_fatal = _utils.string_starts_with(git_root, 'fatal')
 
   if not git_root or git_root_fatal then
-    return vim.fn.fnameescape(vim.loop.cwd())
+    return vim.loop.cwd()
   end
   return git_root
 end

--- a/lua/telescope/_extensions/project/git.lua
+++ b/lua/telescope/_extensions/project/git.lua
@@ -55,12 +55,12 @@ end
 
 -- Attempt to locate git directory, else return cwd
 M.try_and_find_git_path = function()
-  local git_cmd = "git -C " .. vim.loop.cwd() .. " rev-parse --show-toplevel"
-  local git_root = vim.fn.systemlist(git_cmd)[1]
+  local git_cmd = "git -C " .. vim.fn.fnameescape(vim.loop.cwd()) .. " rev-parse --show-toplevel"
+  local git_root = tostring(vim.fn.systemlist(git_cmd)[1]):gsub(".*","")
   local git_root_fatal = _utils.string_starts_with(git_root, 'fatal')
 
   if not git_root or git_root_fatal then
-    return vim.loop.cwd()
+    return vim.fn.fnameescape(vim.loop.cwd())
   end
   return git_root
 end


### PR DESCRIPTION
Currently, I am running into a problem that the path of the added project is after some color sequence coding:
![image](https://user-images.githubusercontent.com/45414421/176604995-28742502-a83e-4281-aff3-b7ac1f66e0da.png)
Maybe it is due to my `$COLORTERM='truecolor'`.
Part of my `:checkhealth`: 
```
## terminal
  - INFO: key_backspace (kbs) terminfo entry: key_backspace=^H
  - INFO: key_dc (kdch1) terminfo entry: key_dc=\E[3~
  - INFO: $TERM_PROGRAM='WezTerm'
  - INFO: $COLORTERM='truecolor'
```
So I go to `try_and_find_git_path` in `util.lua`, use `gsub` to remove the whole color sequence, which could be invisible on github rendering since it contains the ascii control sequence. They are displayed as "^[" (esc) and "^G" in my neovim:
![image](https://user-images.githubusercontent.com/45414421/176605993-2b0807b8-5dab-4b2f-8648-c0c066637b7f.png)
