### PR TITLE
fix: config example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ require('telescope').setup {
       },
       hidden_files = true, -- default: false
       theme = "dropdown"
+    }
   }
 }
 ```


### PR DESCRIPTION
## Problem
The example around line 100 doesn't work initially.

## Fix
Add missing curly brace so no syntax error is thrown when copying the example.

There's a chance this was intentional, such as showing that this project's setup is a continuation of the `require('telescope').setup()` call. In that case, I think there's more beginner-friendly and clearer ways to signal that intent, which I can work on if necessary!