### PR TITLE
feat/order: fix order by recently opened, add order by setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ Example key map config:
 
 ```lua
 vim.api.nvim_set_keymap(
-    'n',
-    '<C-p>',
-    ":lua require'telescope'.extensions.project.project{}<CR>",
-    {noremap = true, silent = true}
+        'n',
+        '<C-p>',
+        ":lua require'telescope'.extensions.project.project{}<CR>",
+        {noremap = true, silent = true}
 )
 ```
 
@@ -91,11 +91,11 @@ lua require'telescope'.extensions.project.project{ display_type = 'full' }
 
 ## Available setup settings:
 
-| Keys           | Description                                                   | Options                |
-|----------------|---------------------------------------------------------------|------------------------|
-| `base_dirs`    | Array of project base directory configurations                | table (default: nil)   |
-| `hidden_files` | Show hidden files in selected project                         | bool (default: false)  |
-
+| Keys           | Description                                                   | Options                   |
+|----------------|---------------------------------------------------------------|---------------------------|
+| `base_dirs`    | Array of project base directory configurations                | table (default: nil)      |
+| `hidden_files` | Show hidden files in selected project                         | bool (default: false)     |
+| `order_by`     | Order projects by `asc`, `desc`, `recent`                     | string (default: recent)  |
 Setup settings can be added when requiring telescope, as shown below:
 
 ```lua
@@ -110,7 +110,8 @@ require('telescope').setup {
         {path = '~/dev/src5', max_depth = 2},
       },
       hidden_files = true, -- default: false
-      theme = "dropdown"
+      theme = "dropdown",
+      order_by = "asc"
     }
   }
 }

--- a/lua/telescope/_extensions/project/main.lua
+++ b/lua/telescope/_extensions/project/main.lua
@@ -16,6 +16,7 @@ local M = {}
 -- Variables that setup can change
 local base_dirs
 local hidden_files
+local order_by
 
 -- Allow user to set base_dirs
 local theme_opts = {}
@@ -31,6 +32,7 @@ M.setup = function(setup_config)
 
   base_dirs = setup_config.base_dirs or nil
   hidden_files = setup_config.hidden_files or false
+  order_by = setup_config.order_by or "recent"
   _git.update_git_repos(base_dirs)
 end
 
@@ -40,13 +42,13 @@ M.project = function(opts)
   pickers.new(opts, {
     prompt_title = 'Select a project',
     results_title = 'Projects',
-    finder = _finders.project_finder(opts, _utils.get_projects()),
+    finder = _finders.project_finder(opts, _utils.get_projects(order_by)),
     sorter = conf.file_sorter(opts),
     attach_mappings = function(prompt_bufnr, map)
 
       local refresh_projects = function()
         local picker = action_state.get_current_picker(prompt_bufnr)
-        local finder = _finders.project_finder(opts, _utils.get_projects())
+        local finder = _finders.project_finder(opts, _utils.get_projects(order_by))
         picker:refresh(finder, { reset_prompt = true })
       end
 


### PR DESCRIPTION
Hello, here is the fix for recent open project sort and order by setting feature.

In my tests this method not worked as expected

```
M.get_last_accessed_time = function(path)
  local expanded_path = vim.fn.expand(path)
  local fs_stat = vim.loop.fs_stat(expanded_path)
  return fs_stat and fs_stat.atime.sec or 0
end
```

When project change via plugin the **atime** of folder not changed so that we always have same time there and projects are not ordered as expected. However if I use GUI (the finder in my PC) and go to the project folder > the **atime** change.
As a workaround I stored the last accessed time in project string.
In addition added new setting **order_by** so that we can order projects asc, desc and recent(default)

Please check if it's ok for you

Thanks

