### PR TITLE
fix: move focus to previous buffer after nvimtree.open()

### DIFF
--- a/lua/telescope/_extensions/project/utils.lua
+++ b/lua/telescope/_extensions/project/utils.lua
@@ -121,6 +121,7 @@ M.open_in_nvim_tree = function(project_path)
     if status_ok then
       nvim_tree.change_dir(project_path)
       nvim_tree.open(project_path)
+      vim.cmd('wincmd p')
     end
 end
 


### PR DESCRIPTION
fix https://github.com/nvim-telescope/telescope-project.nvim/issues/113