### PR TITLE
Add ability to change default action

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,16 +91,18 @@ lua require'telescope'.extensions.project.project{ display_type = 'full' }
 
 ## Available setup settings:
 
-| Keys                  | Description                                    | Options                  |
-|-----------------------|------------------------------------------------|--------------------------|
-| `base_dirs`           | Array of project base directory configurations | table (default: nil)     |
-| `hidden_files`        | Show hidden files in selected project          | bool (default: false)    |
-| `order_by`            | Order projects by `asc`, `desc`, `recent`      | string (default: recent) |
-| `sync_with_nvim_tree` | Sync projects with nvim tree plugin            | bool (default: false)    |
+| Keys                  | Description                                    | Options                                              |
+|-----------------------|------------------------------------------------|------------------------------------------------------|
+| `base_dirs`           | Array of project base directory configurations | table (default: nil)                                 |
+| `hidden_files`        | Show hidden files in selected project          | bool (default: false)                                |
+| `order_by`            | Order projects by `asc`, `desc`, `recent`      | string (default: recent)                             |
+| `sync_with_nvim_tree` | Sync projects with nvim tree plugin            | bool (default: false)                                |
+| `on_project_selected` | Custom handler when project is selected        | function(prompt_bufnr) (default: find project files) |
 Setup settings can be added when requiring telescope, as shown below:
 
 ```lua
 require('telescope').setup {
+  local project_actions = require("telescope._extensions.project.actions")
   extensions = {
     project = {
       base_dirs = {
@@ -114,6 +116,12 @@ require('telescope').setup {
       theme = "dropdown",
       order_by = "asc",
       sync_with_nvim_tree = true, -- default false
+      -- default for on_project_selected = find project files
+      on_project_selected = function(prompt_bufnr)
+        -- Do anything you want in here. For example:
+        project_actions.change_working_directory(prompt_bufnr, false)
+        require("harpoon.ui").nav_file(1)
+      end
     }
   }
 }

--- a/lua/telescope/_extensions/project/main.lua
+++ b/lua/telescope/_extensions/project/main.lua
@@ -17,6 +17,7 @@ local M = {}
 local base_dirs
 local hidden_files
 local order_by
+local on_project_selected
 
 -- Allow user to set base_dirs
 local theme_opts = {}
@@ -33,6 +34,7 @@ M.setup = function(setup_config)
   base_dirs = setup_config.base_dirs or nil
   hidden_files = setup_config.hidden_files or false
   order_by = setup_config.order_by or "recent"
+  on_project_selected = setup_config.on_project_selected
   sync_with_nvim_tree = setup_config.sync_with_nvim_tree or false
   _git.update_git_repos(base_dirs)
 end
@@ -82,10 +84,14 @@ M.project = function(opts)
       -- Workspace key mappings
       map('i', '<c-w>', _actions.change_workspace)
 
-      local on_project_selected = function()
-        _actions.find_project_files(prompt_bufnr, hidden_files)
+      local handler = function()
+        if on_project_selected then
+          on_project_selected(prompt_bufnr)
+        else
+          _actions.find_project_files(prompt_bufnr, hidden_files)
+        end
       end
-      actions.select_default:replace(on_project_selected)
+      actions.select_default:replace(handler)
       return true
     end
   }):find()


### PR DESCRIPTION
This PR allows the user to configure Telescope Project to invoke any arbitrary function as the result of a project being selected. Existing behavior remains unchanged and the user must opt-in to this configuration option.

Example:
```lua
local project_actions = require("telescope._extensions.project.actions")
require('telescope').setup({
  extensions = {
    project = {
      on_project_selected = function(prompt_bufnr)
        project_actions.change_working_directory(prompt_bufnr, false)
        require("harpoon.ui").nav_file(1)
      end
    }
  }
})
require'telescope'.load_extension('project')
```
Closes #119 