### PR TITLE
add option to use both title and path searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ lua require'telescope'.extensions.project.project{ display_type = 'full' }
 | `hidden_files`        | Show hidden files in selected project          | bool (default: false)                                |
 | `order_by`            | Order projects by `asc`, `desc`, `recent`      | string (default: recent)                             |
 | `sync_with_nvim_tree` | Sync projects with nvim tree plugin            | bool (default: false)                                |
-| `search_by`           | Telescope finder search by field (title/path)  | string (default: title)  |
+| `search_by`           | Telescope finder search by field (title/path)  | string or table (default: title). Can also be a table {"title", "path"} to search by both title and path  |
 | `on_project_selected` | Custom handler when project is selected        | function(prompt_bufnr) (default: find project files) |
 Setup settings can be added when requiring telescope, as shown below:
 

--- a/lua/telescope/_extensions/project/finders.lua
+++ b/lua/telescope/_extensions/project/finders.lua
@@ -53,7 +53,15 @@ M.project_finder = function(opts, projects)
       results = projects,
       entry_maker = function(project)
         project.value = project.path
-        project.ordinal = project[search_by]
+        if type(search_by) == "string" then
+          project.ordinal = project[search_by]
+        end
+        if type(search_by) == "table" then
+          project.ordinal = ""
+          for _, property in ipairs(search_by) do
+            project.ordinal = project.ordinal .. " " .. project[property]
+          end
+        end
         project.display = make_display
         return project
       end,


### PR DESCRIPTION
If `search_by` is a table, it adds the option to search by both path and title, by concatenating properties separated by space