### PR TITLE
fix(title): Extract windows project titles

### DIFF
--- a/lua/telescope/_extensions/project/utils.lua
+++ b/lua/telescope/_extensions/project/utils.lua
@@ -86,7 +86,7 @@ end
 -- Parses path into project object (activated by default)
 M.get_project_from_path = function(path)
     -- `tostring` to use plenary path and paths defined as strings
-    local title = tostring(path):match("[^/]+/?$")
+    local title = tostring(path):match("[^\\/]+$")
     local workspace = 'w0'
     local activated = 1
     local line = title .. "=" .. path .. "=" .. workspace .. "=" .. activated


### PR DESCRIPTION
Slight regex modification to support windows folder name extractions
```
# Previously
C:\Users\0x401\source\nvim-telescope => C:\Users\0x401\source\nvim-telescope
# Now
C:\Users\0x401\source\nvim-telescope => nvim-telescope.nvim
```

Won't update existing projects already saved in `telescope-projects.txt`