### PR TITLE
Add add_project_path action

### DIFF
--- a/lua/telescope/_extensions/project/actions.lua
+++ b/lua/telescope/_extensions/project/actions.lua
@@ -53,6 +53,7 @@ local add_project_to_list = function(path)
   end
 
   if path_not_in_projects then
+    -- make a project object from the path
     local new_project = _utils.get_project_from_path(path)
     _utils.store_project(file, new_project)
   end
@@ -65,6 +66,11 @@ end
 -- to the list in the `telescope_projects_file`
 M.add_project_cwd = function()
   local path = vim.loop.cwd()
+  add_project_to_list(path)
+end
+
+-- Create a new project and add it to the list in the `telescope_projects_file`
+M.add_project_path = function(path)
   add_project_to_list(path)
 end
 


### PR DESCRIPTION
The extension didn't have any method for users to add their own projects to it manually.

I wanted to write my own project root directory finder and then add those projects to telescope. This is a good telescope project picker, but it didn't support me adding the projects I found with my own logic.