### PR TITLE
Add support for = and newline in project paths

### DIFF
--- a/lua/telescope/_extensions/project/finders.lua
+++ b/lua/telescope/_extensions/project/finders.lua
@@ -18,16 +18,18 @@ M.project_finder = function(opts, projects)
   -- Loop over all of the projects and find the maximum length of
   -- each of the keys
   for _, project in pairs(projects) do
+    local display_path = project.path:gsub('\n', '\\n') -- otherwise the picker might not open due to a 'Cursor position outside buffer' error
     if display_type == 'full' then
-      project.display_path = '[' .. project.path .. ']'
+      project.display_path = '[' .. display_path .. ']'
     elseif display_type == 'two-segment' then
-      project.display_path = '[' .. string.match(project.path, '([^/]+/[^/]+)/?$') .. ']'
+      project.display_path = '[' .. string.match(display_path, '([^/]+/[^/]+)/?$') .. ']'
     else
       project.display_path = ''
     end
+    project.display_title = project.title:gsub('\n', '\\n')
     local project_path_exists = Path:new(project.path):exists()
     if not project_path_exists then
-      project.title = project.title .. " [deleted]"
+      project.display_title = project.display_title .. " [deleted]"
     end
     for key, value in pairs(widths) do
       widths[key] = math.max(value, strings.strdisplaywidth(project[key] or ''))
@@ -49,7 +51,7 @@ M.project_finder = function(opts, projects)
   local displayer = entry_display.create(create_opts)
   local make_display = function(project)
     local display_opts = {
-      { project.title },
+      { project.display_title },
       { project.display_path }
     }
 

--- a/lua/telescope/_extensions/project/project.lua
+++ b/lua/telescope/_extensions/project/project.lua
@@ -1,0 +1,97 @@
+---@class Project
+---@field title string
+---@field path string
+---@field workspace string
+---@field activated number
+---@field last_accessed_time number|nil A number returned by os.time()
+local Project = {}
+Project.__index = Project
+
+Project.sep = '='
+
+---@param title string
+---@param path string
+---@param workspace string
+---@param activated number
+---@param last_accessed_time number?
+---@return Project
+function Project:new(title, path, workspace, activated, last_accessed_time)
+  local obj = {
+    title = title,
+    path = path,
+    workspace = workspace,
+    last_accessed_time = last_accessed_time,
+    activated = activated,
+  }
+  setmetatable(obj, Project)
+  return obj
+end
+
+---@param sep string the separator being used, which must be escaped as well
+---@param ... string the potentially-multiline strings
+---@return string escape backslashes and newlines to make a recoverable oneline version of str
+local function escape(sep, ...)
+  local args = { n = select('#', ...), ... }
+  local result = {}
+  for _, val in ipairs(args) do
+    local escaped = tostring(val)
+    escaped = escaped:gsub('\\', '\\\\')
+    escaped = escaped:gsub('\n', '\\n')
+    escaped = escaped:gsub(sep, '\\'..sep)
+    table.insert(result, escaped)
+  end
+  return unpack(result)
+end
+
+---@param sep string the separator being used, which must be escaped as well
+---@param ... string the escaped string
+---@return string the original string
+local function unescape(sep, ...)
+  local args = { n = select('#', ...), ... }
+  local result = {}
+  for _, str in ipairs(args) do
+    local original = str:gsub('\\.', {
+      ['\\\\'] = '\\',
+      ['\\n'] = '\n',
+      ['\\'..sep] = sep,
+    })
+    table.insert(result, original)
+  end
+  return unpack(result)
+end
+
+---@return string A oneline string that can later be decoded back into a project. There will not be any newlines in the string.
+function Project:encode()
+  local sep = Project.sep
+  local escaped_parts
+  if self.last_accessed_time then
+    escaped_parts = { escape(sep, self.title, self.path, self.workspace, self.activated, self.last_accessed_time) }
+  else
+    escaped_parts = { escape(sep, self.title, self.path, self.workspace, self.activated) }
+  end
+  local line = table.concat(escaped_parts, sep)
+  return line
+end
+
+Project.__tostring = Project.encode
+
+---@overload fun(self: Project, line: string): Project
+---@overload fun(line: string): Project
+function Project.decode(self, line)
+  if type(self) == 'string' then
+    line = self
+  end
+  local sep = Project.sep
+  local fields = vim.fn.split(line, [[\(\\\)\@<!=]], 1)
+  local title, path, workspace, activated, last_accessed_time = unescape(sep, unpack(fields))
+  if workspace == '' then
+    workspace = 'w0'
+  end
+  activated = tonumber(activated)
+  if not activated then
+    activated = 1
+  end
+  return Project:new(title, path, workspace, activated, tonumber(last_accessed_time))
+end
+
+return Project


### PR DESCRIPTION
The equals sign and the linefeed characters are both valid in file and directory names.

The previous encoding format: https://github.com/nvim-telescope/telescope-project.nvim/blob/34dfa6daa88c132e9e297ff5bd515801a8195eeb/lua/telescope/_extensions/project/utils.lua#L97-L103) 

The previous encoding format breaks when the paths to the projects have equal signs `=` in them, or newlines.

My new representation escapes newlines and equal signs that aren't the intended field separators, so every project is guaranteed to be serialized to a single line, that doesn't lose any information about where fields begin and end.

I made sure the new format is as backwards-compatible as possible with the previous format; the only users who may be affected would have to have `=`, `\`, `\n` characters in their project paths already, which wasn't supported prior to this change (such paths may still be in the storage file, but the plugin had broken behaviour for them).

You still can't open projects that have paths with newline characters from the picker, because of some issue with the `:cd` suite of vim commands, but at least we have a future-proof file format that can reversibly represent all legal paths now.


