### PR TITLE
Add installation section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,34 @@ that allows you to switch between projects.
 - [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) (required)
 - [telescope-file-browser.nvim](https://github.com/nvim-telescope/telescope-file-browser.nvim) (optional, only for `file_browser` action)
 
+## Installation
+
+### Lazy.nvim
+
+```lua
+{
+    'nvim-telescope/telescope-project.nvim',
+    dependencies = {
+        'nvim-telescope/telescope.nvim',
+    },
+}
+```
+
+### packer.nvim
+
+```lua
+use {
+    'nvim-telescope/telescope-project.nvim',
+    requires = {
+        'nvim-telescope/telescope.nvim',
+    },
+}
+```
+
+
 ## Setup
 
-You can setup the extension by adding the following to your config:
+You can set up the extension by adding the following to your config:
 
 ```lua
 require'telescope'.load_extension('project')


### PR DESCRIPTION
To developers unfamiliar with telescope extensions, especially ones under the `nvim-telescope` organization/namespace, it is not clear that this plugin requires explicit installation like any other third-party plugin.

I thought it may have been bundled with telescope, so I tried using

     require'telescope'.extensions.project.project()

a few times before realizing it has to be installed. #99 is an example of someone else who may find this small addition to the readme useful.