### PR TITLE
Make config universal

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,21 +106,10 @@ vim.api.nvim_set_keymap(
 
 ## Available options:
 
-| Keys             | Description                                | Options                       |
-| ---------------- | ------------------------------------------ | ----------------------------- |
-| `display_type`   | Show the title and the path of the project | 'full' or 'minimal' (default) |
-| `hide_workspace` | Hide the workspace of the project          | true or false (default)       |
-
-Options can be added when requiring telescope-project, as shown below:
-
-```lua
-lua require'telescope'.extensions.project.project{ display_type = 'full' }
-```
-
-## Available setup settings:
-
 | Keys                  | Description                                    | Options                                              |
 |-----------------------|------------------------------------------------|------------------------------------------------------|
+| `display_type`        | Show the title and the path of the project     | 'full' or 'minimal' (default)                        |
+| `hide_workspace`      | Hide the workspace of the project              | true or false (default)                              |
 | `base_dirs`           | Array of project base directory configurations | table (default: nil)                                 |
 | `hidden_files`        | Show hidden files in selected project          | bool (default: false)                                |
 | `order_by`            | Order projects by `asc`, `desc`, `recent`      | string (default: recent)                             |
@@ -128,8 +117,15 @@ lua require'telescope'.extensions.project.project{ display_type = 'full' }
 | `search_by`           | Telescope finder search by field (title/path)  | string or table (default: title). Can also be a table {"title", "path"} to search by both title and path  |
 | `on_project_selected` | Custom handler when project is selected        | function(prompt_bufnr) (default: find project files) |
 | `cd_scope`            | Array of cd scopes: `tab`, `window`, `global`  | table (default: {"tab", "window"})                   |
-| `mappings`            | Sets the mappings inside the telescope view    | table (default: the mappings described bellow)        |
-Setup settings can be added when requiring telescope, as shown below:
+| `mappings`            | Sets the mappings inside the telescope view    | table (default: the mappings described bellow)       |
+
+Options can be added when launching the telescope-project picker, as shown below:
+
+```lua
+lua require'telescope'.extensions.project.project{ display_type = 'full' }
+```
+
+The same options can also be provided at setup time to override the defaults, as shown below:
 
 ```lua
 require('telescope').setup {

--- a/lua/telescope/_extensions/project/finders.lua
+++ b/lua/telescope/_extensions/project/finders.lua
@@ -66,12 +66,12 @@ M.project_finder = function(opts, projects)
       results = projects,
       entry_maker = function(project)
         project.value = project.path
-        if type(search_by) == "string" then
-          project.ordinal = project[search_by]
+        if type(opts.search_by) == "string" then
+          project.ordinal = project[opts.search_by]
         end
-        if type(search_by) == "table" then
+        if type(opts.search_by) == "table" then
           project.ordinal = ""
-          for _, property in ipairs(search_by) do
+          for _, property in ipairs(opts.search_by) do
             project.ordinal = project.ordinal .. " " .. project[property]
           end
         end

--- a/lua/telescope/_extensions/project/main.lua
+++ b/lua/telescope/_extensions/project/main.lua
@@ -13,6 +13,20 @@ local _utils = require("telescope._extensions.project.utils")
 
 local M = {}
 
+---@class Config
+---@field base_dirs nil | BaseDirSpec[] Array of project base directory configurations
+---@field hidden_files boolean Show hidden files in selected project
+---@field order_by OrderBy "recent", or alphabetically "asc" or "desc"
+---@field on_project_selected fun(prompt_bufnr: number, hidden_files: boolean) Custom handler when project is selected
+---@field hide_workspace boolean
+---@field display_type string
+---|"'full'"
+---|"'minimal'" (default)
+---@field search_by ProjectFieldName
+---@field sync_with_nvim_tree boolean
+---@field cd_scope table Array of cd scopes: tab, window, global
+---@field theme string | nil a telescope theme name
+---@field mappings table telescope-format table of mappings for the project telescope picker
 local default_config = {
   base_dirs = nil,
   hidden_files = false,
@@ -52,6 +66,7 @@ local default_config = {
     },
   },
 }
+
 -- copy of default_config that setup can change
 local config
 

--- a/lua/telescope/_extensions/project/main.lua
+++ b/lua/telescope/_extensions/project/main.lua
@@ -13,82 +13,75 @@ local _utils = require("telescope._extensions.project.utils")
 
 local M = {}
 
--- Variables that setup can change
-local base_dirs
-local hidden_files
-local order_by
-local on_project_selected
-local mappings = {
-  n = {
-    ['d'] = _actions.delete_project,
-    ['r'] = _actions.rename_project,
-    ['c'] = _actions.add_project,
-    ['C'] = _actions.add_project_cwd,
-    ['f'] = _actions.find_project_files,
-    ['b'] = _actions.browse_project_files,
-    ['s'] = _actions.search_in_project_files,
-    ['R'] = _actions.recent_project_files,
-    ['w'] = _actions.change_working_directory,
-    ['o'] = _actions.next_cd_scope,
+local default_config = {
+  base_dirs = nil,
+  hidden_files = false,
+  order_by = "recent",
+  on_project_selected = _actions.find_project_files,
+  hide_workspace = false,
+  display_type = 'minimal',
+  search_by = 'title',
+  sync_with_nvim_tree = false,
+  cd_scope = { "tab", "window" },
+  theme = nil,
+  mappings = {
+    n = {
+      ['d'] = _actions.delete_project,
+      ['r'] = _actions.rename_project,
+      ['c'] = _actions.add_project,
+      ['C'] = _actions.add_project_cwd,
+      ['f'] = _actions.find_project_files,
+      ['b'] = _actions.browse_project_files,
+      ['s'] = _actions.search_in_project_files,
+      ['R'] = _actions.recent_project_files,
+      ['w'] = _actions.change_working_directory,
+      ['o'] = _actions.next_cd_scope,
+    },
+    i = {
+      ['<c-d>'] = _actions.delete_project,
+      ['<c-v>'] = _actions.rename_project,
+      ['<c-a>'] = _actions.add_project,
+      ['<c-A>'] = _actions.add_project_cwd,
+      ['<c-f>'] = _actions.find_project_files,
+      ['<c-b>'] = _actions.browse_project_files,
+      ['<c-s>'] = _actions.search_in_project_files,
+      ['<c-r>'] = _actions.recent_project_files,
+      ['<c-l>'] = _actions.change_working_directory,
+      ['<c-o>'] = _actions.next_cd_scope,
+      ['<c-w>'] = _actions.change_workspace,
+    },
   },
-  i = {
-    ['<c-d>'] = _actions.delete_project,
-    ['<c-v>'] = _actions.rename_project,
-    ['<c-a>'] = _actions.add_project,
-    ['<c-A>'] = _actions.add_project_cwd,
-    ['<c-f>'] = _actions.find_project_files,
-    ['<c-b>'] = _actions.browse_project_files,
-    ['<c-s>'] = _actions.search_in_project_files,
-    ['<c-r>'] = _actions.recent_project_files,
-    ['<c-l>'] = _actions.change_working_directory,
-    ['<c-o>'] = _actions.next_cd_scope,
-    ['<c-w>'] = _actions.change_workspace,
-  }
 }
-
+-- copy of default_config that setup can change
+local config
 
 -- Allow user to set base_dirs
 local theme_opts = {}
 M.setup = function(setup_config)
-  if setup_config.base_dir then
+  config = vim.tbl_deep_extend('force', default_config, setup_config)
+  if config.base_dir then
     error("'base_dir' is no longer a valid value for setup. See 'base_dirs'")
   end
 
-  if setup_config.theme and setup_config.theme ~= "" then
-    theme_opts = themes["get_" .. setup_config.theme]()
+  if config.theme and config.theme ~= "" then
+    theme_opts = themes["get_" .. config.theme]()
   end
-
-  base_dirs = setup_config.base_dirs or nil
-  hidden_files = setup_config.hidden_files or false
-  order_by = setup_config.order_by or "recent"
-  on_project_selected = setup_config.on_project_selected
-  search_by = setup_config.search_by or "title"
-  sync_with_nvim_tree = setup_config.sync_with_nvim_tree or false
-  local cd_scope = setup_config.cd_scope or { "tab", "window" }
-  _actions.set_cd_scope(cd_scope)
-  _git.update_git_repos(base_dirs)
-
-  local config_maps = setup_config.mappings or {}
-  for mode, maps in pairs(config_maps) do
-    maps = maps or {}
-    for keys, action in pairs(maps) do
-      mappings[mode][keys] = action
-    end
-  end
+  _actions.set_cd_scope(config.cd_scope)
+  _git.update_git_repos(config.base_dirs)
 end
 
 -- This creates a picker with a list of all of the projects
 M.project = function(opts)
-  opts = vim.tbl_deep_extend("force", theme_opts, opts or {})
+  opts = vim.tbl_deep_extend("force", theme_opts, config, opts or {})
   pickers.new(opts, {
     prompt_title = 'Select a project ' .. '(' .. _actions.get_cd_scope() .. ')',
     results_title = 'Projects',
-    finder = _finders.project_finder(opts, _utils.get_projects(order_by)),
+    finder = _finders.project_finder(opts, _utils.get_projects(config.order_by)),
     sorter = conf.file_sorter(opts),
     attach_mappings = function(prompt_bufnr, map)
       local refresh_projects = function()
         local picker = action_state.get_current_picker(prompt_bufnr)
-        local finder = _finders.project_finder(opts, _utils.get_projects(order_by))
+        local finder = _finders.project_finder(opts, _utils.get_projects(config.order_by))
         picker:refresh(finder, { reset_prompt = true })
       end
 
@@ -97,18 +90,14 @@ M.project = function(opts)
       _actions.delete_project:enhance({ post = refresh_projects })
       _actions.rename_project:enhance({ post = refresh_projects })
 
-      for mode, maps in pairs(mappings) do
+      for mode, maps in pairs(config.mappings) do
         for keys, action in pairs(maps) do
           map(mode, keys, action)
         end
       end
 
       local handler = function()
-        if on_project_selected then
-          on_project_selected(prompt_bufnr)
-        else
-          _actions.find_project_files(prompt_bufnr, hidden_files)
-        end
+        config.on_project_selected(prompt_bufnr, config.hidden_files)
       end
       actions.select_default:replace(handler)
       return true

--- a/lua/telescope/_extensions/project/types.lua
+++ b/lua/telescope/_extensions/project/types.lua
@@ -21,4 +21,3 @@
 ---@field max_depth integer Defaults to 3
 
 ---@alias BaseDirSpec string|BaseDirArray|BaseDirPath
-

--- a/lua/telescope/_extensions/project/types.lua
+++ b/lua/telescope/_extensions/project/types.lua
@@ -7,6 +7,13 @@
 ---@field activated number
 ---@field last_accessed_time number? A number returned by [os.time](lua://os.time)
 
+---@alias ProjectFieldName
+---|"'title'"
+---|"'path'"
+---|"'workspace'"
+---|"'activated'"
+---|"'last_accessed_time'"
+
 ---@class BaseDirMaxDepth
 ---@field max_depth? integer Defaults to 3
 
@@ -21,3 +28,8 @@
 ---@field max_depth integer Defaults to 3
 
 ---@alias BaseDirSpec string|BaseDirArray|BaseDirPath
+
+---@alias OrderBy
+---|"'asc'" # compares alphabetically, case-insensitive
+---|"'desc'"
+---|"'recent'" # uses last_accessed_time, most recent first

--- a/lua/telescope/_extensions/project/utils.lua
+++ b/lua/telescope/_extensions/project/utils.lua
@@ -23,10 +23,7 @@ end
 ---Fetches project information to be passed to picker
 ---
 ---The results will only include activated projects
----@param order_by string
----|"'asc'" # compares alphabetically, case-insensitive
----|"'desc'"
----|"'recent'" # uses last_accessed_time, most recent first
+---@param order_by OrderBy
 ---@return Project[]
 M.get_projects = function(order_by)
   local filtered_projects = {}


### PR DESCRIPTION
I had

```lua
require("telescope").setup {
    extensions = {
        project = {
            hidden_files = true, -- default: false
            display_type = 'full', -- default is 'minimal' which only shows name but not path
            hide_workspace = true, -- default: false
        },
    },

```

In my vimrc for the longest time without noticing my settings weren't having any effects.

In taking a look at @akkaargh's comment in #165, I noticed that there were two types of settings for this plugin: picker-time settings and setup-time settings.

Actually, it seems like all options make sense to be able to apply both at setup time and at picker-open time, so I've merged them.

After this PR, my config will start to work as I had originally expected it to.