### PR TITLE
Add 'ignore_missing_dirs' option to not show warnings when one or more base_dirs are missing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ lua require'telescope'.extensions.project.project{ display_type = 'full' }
 | Keys                  | Description                                    | Options                                              |
 |-----------------------|------------------------------------------------|------------------------------------------------------|
 | `base_dirs`           | Array of project base directory configurations | table (default: nil)                                 |
+| `ignore_missing_dirs` | Don't show an error if base dirs are missing   | bool (default: false)                                 |
 | `hidden_files`        | Show hidden files in selected project          | bool (default: false)                                |
 | `order_by`            | Order projects by `asc`, `desc`, `recent`      | string (default: recent)                             |
 | `sync_with_nvim_tree` | Sync projects with nvim tree plugin            | bool (default: false)                                |
@@ -143,6 +144,7 @@ require('telescope').setup {
         {path = '~/dev/src4'},
         {path = '~/dev/src5', max_depth = 2},
       },
+      ignore_missing_dirs = true, -- default: false
       hidden_files = true, -- default: false
       theme = "dropdown",
       order_by = "asc",

--- a/lua/telescope/_extensions/project/git.lua
+++ b/lua/telescope/_extensions/project/git.lua
@@ -6,21 +6,22 @@ local scan = require("plenary.scandir")
 local M = {}
 
 -- Find and store git repos if base_dirs provided
-M.update_git_repos = function(base_dirs)
+M.update_git_repos = function(base_dirs, ignore_missing_dirs)
   if base_dirs then
     local normalized_config = _utils.normalize_base_dir_configs(base_dirs)
-    local repo_paths  = M.search_for_git_repos(normalized_config)
+    local repo_paths  = M.search_for_git_repos(normalized_config, ignore_missing_dirs)
     local git_projects = M.parse_git_repo_paths(repo_paths)
     M.save_git_repos(git_projects)
   end
 end
 
 -- Recurses directories under base directories to find all git projects
-M.search_for_git_repos = function(base_dirs)
+M.search_for_git_repos = function(base_dirs, ignore_missing_dirs)
   return iter.iter(base_dirs)
     :map(function(base_dir)
       local git_dirs = scan.scan_dir(vim.fn.expand(base_dir.path), {
         depth = base_dir.max_depth,
+        silent = ignore_missing_dirs,
         add_dirs = true,
         hidden = true,
         search_pattern = "%.git$"

--- a/lua/telescope/_extensions/project/main.lua
+++ b/lua/telescope/_extensions/project/main.lua
@@ -15,6 +15,7 @@ local M = {}
 
 -- Variables that setup can change
 local base_dirs
+local ignore_missing_dirs
 local hidden_files
 local order_by
 local on_project_selected
@@ -59,6 +60,7 @@ M.setup = function(setup_config)
   end
 
   base_dirs = setup_config.base_dirs or nil
+  ignore_missing_dirs = setup_config.ignore_missing_dirs or false
   hidden_files = setup_config.hidden_files or false
   order_by = setup_config.order_by or "recent"
   on_project_selected = setup_config.on_project_selected
@@ -66,7 +68,7 @@ M.setup = function(setup_config)
   sync_with_nvim_tree = setup_config.sync_with_nvim_tree or false
   local cd_scope = setup_config.cd_scope or { "tab", "window" }
   _actions.set_cd_scope(cd_scope)
-  _git.update_git_repos(base_dirs)
+  _git.update_git_repos(base_dirs, ignore_missing_dirs)
 
   local config_maps = setup_config.mappings or {}
   for mode, maps in pairs(config_maps) do


### PR DESCRIPTION
This adds an option to the setup config to not show a warning if one or more directories listed in the "base_dirs" table is missing.

Resolves #169 