### PR TITLE
Replace C-w with C-c

### DIFF
--- a/lua/telescope/_extensions/project/main.lua
+++ b/lua/telescope/_extensions/project/main.lua
@@ -43,7 +43,7 @@ local mappings = {
     ['<c-r>'] = _actions.recent_project_files,
     ['<c-l>'] = _actions.change_working_directory,
     ['<c-o>'] = _actions.next_cd_scope,
-    ['<c-w>'] = _actions.change_workspace,
+    ['<c-k>'] = _actions.change_workspace,
   }
 }
 

--- a/lua/telescope/_extensions/project/main.lua
+++ b/lua/telescope/_extensions/project/main.lua
@@ -43,7 +43,7 @@ local mappings = {
     ['<c-r>'] = _actions.recent_project_files,
     ['<c-l>'] = _actions.change_working_directory,
     ['<c-o>'] = _actions.next_cd_scope,
-    ['<c-k>'] = _actions.change_workspace,
+    ['<c-c>'] = _actions.change_workspace,
   }
 }
 


### PR DESCRIPTION
C-w should really be used to delete a backwards word ,  currently if you press C-w when you started to type something by mistake it errors out with an exception.